### PR TITLE
Change base image to jenkins/jenkins:lts-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:alpine
+FROM jenkins/jenkins:lts-alpine
 LABEL maintainer "socialplus_admin@feedforce.jp"
 
 ENV JENKINS_OPTS --sessionTimeout=1440


### PR DESCRIPTION
## Why?

`jenkins` image is deprecated.

> DEPRECATION NOTICE
> This image has been deprecated in favor of the jenkins/jenkins:lts image provided and maintained by Jenkins Community as part of project's release process. The images found here will receive no further updates after LTS 2.60.x. Please adjust your usage accordingly.
>
> https://hub.docker.com/_/jenkins/

## How to check?

1. Uncomment this
    
    ```diff
    diff --git a/docker-compose.yml b/docker-compose.yml
    index 3bace79..70fe8a6 100644
    --- a/docker-compose.yml
    +++ b/docker-compose.yml
    @@ -2,7 +2,7 @@ version: "3"
     services:
       jenkins:
         image: feedforce/socialplus-jenkins
    -    # build: . # for development
    +    build: . # for development
         restart: always
         ports:
           - "8080:8080"
    ```

1. `$ docker-compose build && docker-compose up -d`
1. Open http://localhost:8080
1. Initial Jenkins settings
1. When the dashboard is displayed OK

    ![image](https://user-images.githubusercontent.com/10208211/48469824-26661300-e833-11e8-9557-069d1c2152f3.png)

## What if I want to use the previous image?

I pushed the `feedforce/socialplus-jenkins:2.60.3` tag to DockerHub.

![image](https://user-images.githubusercontent.com/10208211/48469916-544b5780-e833-11e8-94dc-ceb28017a61f.png)

Please use this image.