### PR TITLE
Install shared-mime-info package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
         mariadb-dev \
         python-dev \
         py-pip \
-        rsync && \
+        rsync \
+        shared-mime-info && \
     pip install --upgrade pip && \
     pip install awscli
 USER jenkins


### PR DESCRIPTION
## Why?

To install mimemagic gem.

The `shared-mime-info` package search method is as follows.

> ![image](https://user-images.githubusercontent.com/10208211/112774093-7431ed80-9073-11eb-9153-0d33451fd81d.png)
>
> https://pkgs.alpinelinux.org/packages?name=*mime-info*&branch=v3.13&arch=x86_64