### PR TITLE
Fix failure to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apk add --no-cache \
         readline-dev \
         zlib-dev \
         mariadb-dev \
-        python-dev \
-        py-pip \
+        python3-dev \
+        py3-pip \
         rsync && \
     pip install --upgrade pip && \
     pip install awscli


### PR DESCRIPTION
## Why?

Automatic build was failed of Docker Hub.

![image](https://user-images.githubusercontent.com/10208211/112773135-c5d87900-906f-11eb-865e-84c67ea0e2ff.png)

`python-dev` and `py-pip` packages were deleted from Alpine Linux v3.12.0.

> **python2 no longer provides python and python-devel**
>
> python2 no longer provides python and python-devel, nothing does, it is now required that you explicitly depend on either python2 or python3, any new contributions that depend on python2 will be rejected summarily, and python2 is in the process of being **completely** removed
>
> https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.12.0

## How?

Install `python3-dev`, `py3-pip` packages instead of `python-dev`, `py-pip`.

fixed.

![image](https://user-images.githubusercontent.com/10208211/112773559-7135fd80-9071-11eb-87e8-2301916c9206.png)